### PR TITLE
fix: TypeError: Cannot read properties of null (reading 'file')

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -53,7 +53,7 @@ const plugin = (fpAPI) => {
 
           // don't do anything while not an PDF
           if (
-            ( !isPreviewablePdf(item.file) ) ||
+            ( !item || !isPreviewablePdf(item.file) ) ||
             root.rect.element.hidden
           )
             return;


### PR DESCRIPTION
When unloading a filepond instance this error would appear

![image](https://user-images.githubusercontent.com/6115458/177195136-a3806223-2e29-4897-b357-73cd268827fd.png)
